### PR TITLE
Add feature to send broadcast message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 [![CircleCI](https://circleci.com/gh/tamano/chatwork-task-linker.svg?&style=shield&circle-token=b3d42997c87453923aaec24ca2535819b9fee6ee)](https://circleci.com/gh/tamano/chatwork-task-linker) [![Dependency Status](https://gemnasium.com/tamano/chatwork-task-linker.svg)](https://gemnasium.com/tamano/chatwork-task-linker)
 
 Copy ChatWork's task to another web services.
+
+# Environment values needed
+- CHATWORK_SYSBOT_API_TOKEN
+  - API Token use to login to Chatwork
+- CHATWORK_SYSBOT_BROADCAST_ROOM_ID
+  - Room ID of Chatwork which used to send message to everyone.
+- CHATWORK_SYSBOT_BROADCAST_TO
+  - User IDs(seperated with comma) of everyone.

--- a/app/services/chatwork_message_service.rb
+++ b/app/services/chatwork_message_service.rb
@@ -12,6 +12,11 @@ class ChatworkMessageService
     ChatWork::Message.create(room_id: room_id, body: message)
   end
 
+  def send_message_to(room_id, user_ids, message)
+    to_text = user_ids.map { |v| "[To:#{v}]"}.join
+    send_message(room_id, to_text + "\n" + message)
+  end
+
   def send_personal_message(name, message)
     ChatWork.api_key = @user.setting.chatwork_token
     direct_rooms = fetch_direct_rooms

--- a/app/services/chatwork_message_service.rb
+++ b/app/services/chatwork_message_service.rb
@@ -13,7 +13,7 @@ class ChatworkMessageService
   end
 
   def send_message_to(room_id, user_ids, message)
-    to_text = user_ids.map { |v| "[To:#{v}]"}.join
+    to_text = user_ids.map { |v| "[To:#{v}]" }.join
     send_message(room_id, to_text + "\n" + message)
   end
 

--- a/lib/tasks/chatwork_broadcast_message.rake
+++ b/lib/tasks/chatwork_broadcast_message.rake
@@ -1,0 +1,11 @@
+namespace :chatwork_broadcast_message do
+  desc "Send message to everyone."
+  task :send, [:message] => :environment do |task, args|
+    room_id = ENV['CHATWORK_SYSBOT_BROADCAST_ROOM_ID']
+    user_ids = ENV['CHATWORK_SYSBOT_BROADCAST_TO'].split(',')
+    message = args.message
+
+    service = ChatworkMessageService.new(User.find(1))
+    service.send_message_to(room_id, user_ids, message)
+  end
+end

--- a/lib/tasks/chatwork_broadcast_message.rake
+++ b/lib/tasks/chatwork_broadcast_message.rake
@@ -1,6 +1,6 @@
 namespace :chatwork_broadcast_message do
-  desc "Send message to everyone."
-  task :send, [:message] => :environment do |task, args|
+  desc 'Send message to everyone.'
+  task :send, [:message] => :environment do |_task, args|
     room_id = ENV['CHATWORK_SYSBOT_BROADCAST_ROOM_ID']
     user_ids = ENV['CHATWORK_SYSBOT_BROADCAST_TO'].split(',')
     message = args.message


### PR DESCRIPTION
New task `rake "chatwork_broadcast_message.send[message]"` send `message` to chat room `ENV["CHATWORK_SYSBOT_BROADCAST_ROOM_ID"]` with _TO:_ tag for user_ids in `ENV["CHATWORK_SYSBOT_BROADCAST_TO"]`
